### PR TITLE
add Project specific branch naming convention in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | test     | for experimenting and testing      |
 | feature  | for adding or removing features    |
 
-### Branching naming example
+### Branch naming example
 
-- "category/ { issue }" 
-- E.g. feature/3-login-for-cool-website
+- Template: "category/ { issue name }" 
+- Example: feature/3-login-for-cool-website

--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@
 -  PostgreSQL
 -  GitHub Actions
 
+## Project specific branch naming convention
+| Category | Description                        |
+|----------|------------------------------------|
+| bugfix   | for fixing a bug                   |
+| hotfix   | for quickly fixing critical issues |
+| test     | for experimenting and testing      |
+| feature  | for adding or removing features    |
+
+### Branching naming example
+
+- "category/ { issue }" 
+- E.g. feature/3-login-for-cool-website


### PR DESCRIPTION
I added a table with all categories and descriptions and two examples.