### PR TITLE
overhaul Dockerfile (again) for a smaller image

### DIFF
--- a/paperlessREST/Dockerfile
+++ b/paperlessREST/Dockerfile
@@ -1,18 +1,36 @@
-# syntax=docker/dockerfile:experimental
-# https://stackoverflow.com/a/60523058
+# base image to build a JRE
+FROM maven:3.9.5-eclipse-temurin-17-alpine as temurin
 
 
 # fetch dependencies
-FROM maven:3.8.5-openjdk-17 as build
 COPY pom.xml .
 RUN mvn -B -f pom.xml dependency:go-offline
 COPY . .
 RUN mvn -B install
 
 
-# build artifact
-FROM openjdk:17-jdk-alpine
-COPY --from=build ./target/paperlessREST-1.0.0.jar ./
+# required for strip-debug to work
+RUN apk add --no-cache binutils
+
+# Build small JRE image
+RUN $JAVA_HOME/bin/jlink \
+         --verbose \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /customjre
+
+
+# main app image
+FROM alpine
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=temurin /customjre $JAVA_HOME
+COPY --from=temurin ./target/paperlessREST-1.0.0.jar ./
+
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/paperlessREST-1.0.0.jar"]
+ENTRYPOINT ["/jre/bin/java", "-jar", "/paperlessREST-1.0.0.jar"]


### PR DESCRIPTION
This involves using the `eclipse-temurin` image, which is apparently the successor to the now-deprecated `openjdk` image, creating a slim JRE with `jlink`, building the jar as usual, and then only using the new, slim JRE to run the jar in the resulting image. This results in an image of ~140MB instead of ~340MB. 