### PR TITLE
Create wrapper service in paperlessREST to avoid dependencies between DocumentService, MinIO, and RabbitMQ

### DIFF
--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/models/entity/DocumentEntity.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/models/entity/DocumentEntity.java
@@ -29,9 +29,7 @@ public class DocumentEntity {
     @Size(max = 40, message = "A valid document title must contain less than 40 characters")
     private String title;
 
-    @Column(length = 4096)
-    @NotNull(message = "Document content cannot be null")
-    @NotEmpty(message = "Document content cannot be empty")
+    @Lob
     private String content;
 
     private String createdDate;

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/DispatcherService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/DispatcherService.java
@@ -1,0 +1,38 @@
+package at.fhtw.swen3.paperless.services;
+
+import at.fhtw.swen3.paperless.services.customDTOs.PostDocumentRequestDto;
+import at.fhtw.swen3.paperless.services.messageQueue.MQService;
+import at.fhtw.swen3.paperless.services.minio.MinioService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class DispatcherService implements IDispatcherService {
+
+    Logger logger = LogManager.getLogger(DispatcherService.class);
+
+    private final DocumentService documentService;
+    private final MQService mqService;
+    private final MinioService minioService;
+
+    @Autowired
+    public DispatcherService(DocumentService documentService, MQService mqService,
+            MinioService minioService) {
+        this.documentService = documentService;
+        this.mqService = mqService;
+        this.minioService = minioService;
+    }
+
+    @Override
+    public void handleDocument(MultipartFile file, PostDocumentRequestDto postDocRequestDto) {
+       var mappedDocumentEntity = documentService.saveDocument(postDocRequestDto);
+        minioService.handleFileUpload(file);
+
+        // TODO: figure out what the exact content of the message should be
+        mqService.processMessage(String.format("[ID: %d]\n[Name: %s]", mappedDocumentEntity.getId(), mappedDocumentEntity.getTitle()));
+    }
+
+}

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/DocumentService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/DocumentService.java
@@ -1,5 +1,6 @@
 package at.fhtw.swen3.paperless.services;
 
+import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
 import at.fhtw.swen3.paperless.repositories.DocumentRepository;
 import at.fhtw.swen3.paperless.services.customDTOs.PostDocumentRequestDto;
 import at.fhtw.swen3.paperless.services.mapper.PostDocumentMapper;
@@ -15,25 +16,19 @@ public class DocumentService implements IDocumentService {
     Logger logger = LogManager.getLogger(DocumentService.class);
 
     private final DocumentRepository documentRepository;
-    private final MQService mqService;
-    private final MinioService minioService;
 
-    public DocumentService(DocumentRepository documentRepository, MQService mqService,
-            MinioService minioService) {
+    public DocumentService(DocumentRepository documentRepository) {
         this.documentRepository = documentRepository;
-        this.mqService = mqService;
-        this.minioService = minioService;
     }
 
     @Override
-    public void saveDocument(PostDocumentRequestDto postDocumentRequestDto) {
+    public DocumentEntity saveDocument(PostDocumentRequestDto postDocumentRequestDto) {
 
         try {
             var mappedDocumentEntity = PostDocumentMapper.INSTANCE.dtoToEntity(postDocumentRequestDto);
             documentRepository.save(mappedDocumentEntity);
 
-            mqService.processMessage(String.format("Save document with title %s", postDocumentRequestDto.getTitle()));
-            minioService.putDocument(mappedDocumentEntity);
+            return mappedDocumentEntity;
         } catch (Exception e) {
 
             this.logger.error(String.format("Error saving document \n%s", e));

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/IDispatcherService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/IDispatcherService.java
@@ -1,0 +1,8 @@
+package at.fhtw.swen3.paperless.services;
+
+import org.springframework.web.multipart.MultipartFile;
+import at.fhtw.swen3.paperless.services.customDTOs.PostDocumentRequestDto;
+
+public interface IDispatcherService {
+    void handleDocument(MultipartFile file, PostDocumentRequestDto postDocRequestDto);
+}

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/IDocumentService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/IDocumentService.java
@@ -1,7 +1,8 @@
 package at.fhtw.swen3.paperless.services;
 
+import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
 import at.fhtw.swen3.paperless.services.customDTOs.PostDocumentRequestDto;
 
 public interface IDocumentService {
-    void saveDocument(PostDocumentRequestDto postDocumentRequestDto);
+    DocumentEntity saveDocument(PostDocumentRequestDto postDocumentRequestDto);
 }

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/customDTOs/PostDocumentRequestDto.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/customDTOs/PostDocumentRequestDto.java
@@ -18,9 +18,6 @@ public class PostDocumentRequestDto {
     private Integer documentType;
     private List<Integer> tags;
     private Integer correspondent;
-    private String documentContentBase64;
-    // TODO implement mapping and parsing
-    // private List<MultipartFile> document;
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("class PostDocumentRequestDto {\n");
@@ -28,7 +25,6 @@ public class PostDocumentRequestDto {
         sb.append("    offsetDateTime: ").append(toIndentedString(offsetDateTime)).append("\n");
         sb.append("    documentType: ").append(toIndentedString(documentType)).append("\n");
         sb.append("    correspondent: ").append(toIndentedString(correspondent)).append("\n");
-        sb.append("    documentContentBase64: ").append(toIndentedString(documentContentBase64)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/mapper/PostDocumentMapper.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/mapper/PostDocumentMapper.java
@@ -17,7 +17,6 @@ public interface PostDocumentMapper extends BaseMapper<DocumentEntity, PostDocum
     @Mapping(source="correspondent", target = "correspondent")
     @Mapping(source="documentType", target = "documentType")
     @Mapping(source="offsetDateTime", target = "createdDate", qualifiedByName = "parseOffSetToString")
-    @Mapping(source = "documentContentBase64", target = "content")
     DocumentEntity dtoToEntity(PostDocumentRequestDto postDocumentRequestDto);
 
     @Named("parseOffSetToString")

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/MinioService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/MinioService.java
@@ -4,6 +4,7 @@ import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;
 import lombok.Getter;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
 import io.minio.MinioClient;
@@ -11,6 +12,8 @@ import io.minio.PutObjectArgs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Base64;
 
 @Component
 public class MinioService {
@@ -23,15 +26,15 @@ public class MinioService {
     // TODO maybe make a config class and inject it in the constructor instead
     @Getter
     private final MinioClient minioClient =
-            MinioClient.builder().endpoint("http://minio:9000")
-                    .credentials("paperless_minio", "paperless").build();
+        MinioClient.builder().endpoint("http://minio:9000")
+            .credentials("paperless_minio", "paperless").build();
 
     public MinioService() {
         // how many of these logging statements is too many? great logger by the way @Billojullo
         this.logger.info(String.format("Connecting to MinIO\n"));
         try {
             if (!this.minioClient.bucketExists(
-                    BucketExistsArgs.builder().bucket(BUCKET_NAME).build()))
+                BucketExistsArgs.builder().bucket(BUCKET_NAME).build()))
                 this.createBucket(BUCKET_NAME);
         } catch (Exception e) {
             this.logger.error(String.format("Error initializing MinIO \n%s", e));
@@ -47,24 +50,44 @@ public class MinioService {
         }
     }
 
-    public void putDocument(DocumentEntity document) {
+    public void handleFileUpload(MultipartFile document) {
+
         try {
+            if (document.isEmpty()) {
+                throw new Exception("Failed to store empty file.");
+            }
+
+            try (InputStream inputStream = document.getInputStream()) {
+                minioClient.putObject(PutObjectArgs
+                    .builder()
+                    .bucket(BUCKET_NAME)
+                    .object(document.getOriginalFilename())
+                    .stream(inputStream, document.getSize(), -1).build());
+            }
+
             // serialized into json; do we need this really or can we just upload it somehow?
-            ObjectMapper om = new ObjectMapper();
-            String doc = om.writeValueAsString(document);
-            var fileAsByteArray =
-                    new ByteArrayInputStream(om.writeValueAsBytes(document));
+            // ObjectMapper om = new ObjectMapper();
+            // String doc = om.writeValueAsString(document);
+            // String doc = document.getContent();
+            // var fileAsByteArray =
+            // new ByteArrayInputStream(om.writeValueAsBytes(document));
+
+            // TODO the DocumentEntity should not actually have this in the content
+            // byte[] file = Base64.getDecoder().decode(document.getContent());
+            // var fileAsByteArray =
+            // new ByteArrayInputStream(file);
 
             // this stream function is somewhat difficult to use; you need to give it either
             // an object size or a part size, but I don't see an easy way to find the actual size here
-            this.minioClient.putObject(PutObjectArgs.builder().bucket(BUCKET_NAME)
-                    .object(document.getTitle())
-                    .stream(fileAsByteArray, doc.length(), -1).build());
+            // this.minioClient.putObject(PutObjectArgs.builder().bucket(BUCKET_NAME)
+            // .object(document.getTitle())
+            // .stream(fileAsByteArray, file.length, -1).build());
 
-            this.logger.info(String.format("Uploading document to MinIO: %s\n", doc));
+            this.logger.info(String.format("Uploading document to MinIO: %s\n",
+                document.getOriginalFilename()));
         } catch (Exception e) {
             this.logger.error(String.format("Error placing document: %s\n%s",
-                    document.getTitle(), e));
+                document.getOriginalFilename(), e));
         }
     }
 

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/MinioService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/MinioService.java
@@ -5,15 +5,11 @@ import io.minio.MakeBucketArgs;
 import lombok.Getter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Base64;
 
 @Component
 public class MinioService {
@@ -64,24 +60,6 @@ public class MinioService {
                     .object(document.getOriginalFilename())
                     .stream(inputStream, document.getSize(), -1).build());
             }
-
-            // serialized into json; do we need this really or can we just upload it somehow?
-            // ObjectMapper om = new ObjectMapper();
-            // String doc = om.writeValueAsString(document);
-            // String doc = document.getContent();
-            // var fileAsByteArray =
-            // new ByteArrayInputStream(om.writeValueAsBytes(document));
-
-            // TODO the DocumentEntity should not actually have this in the content
-            // byte[] file = Base64.getDecoder().decode(document.getContent());
-            // var fileAsByteArray =
-            // new ByteArrayInputStream(file);
-
-            // this stream function is somewhat difficult to use; you need to give it either
-            // an object size or a part size, but I don't see an easy way to find the actual size here
-            // this.minioClient.putObject(PutObjectArgs.builder().bucket(BUCKET_NAME)
-            // .object(document.getTitle())
-            // .stream(fileAsByteArray, file.length, -1).build());
 
             this.logger.info(String.format("Uploading document to MinIO: %s\n",
                 document.getOriginalFilename()));

--- a/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/PostDocumentMapperTests.java
+++ b/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/PostDocumentMapperTests.java
@@ -19,7 +19,6 @@ public class PostDocumentMapperTests {
         postDocumentRequestDto.setDocumentType(1);
         postDocumentRequestDto.setTags(List.of(1,2,3));
         postDocumentRequestDto.setCorrespondent(2);
-        postDocumentRequestDto.setDocumentContentBase64("I am a 64 encoded content");
 
         var result = PostDocumentMapper.INSTANCE.dtoToEntity(postDocumentRequestDto);
 
@@ -27,7 +26,6 @@ public class PostDocumentMapperTests {
         assertNotEquals(null, result.getCreatedDate());
         assertEquals(postDocumentRequestDto.getDocumentType(), result.getDocumentType());
         assertEquals(postDocumentRequestDto.getCorrespondent(), result.getCorrespondent());
-        assertEquals(postDocumentRequestDto.getDocumentContentBase64(), result.getContent());
 
     }
 }


### PR DESCRIPTION
This turned into a huge rabbit hole, and it will be difficult to tell what's happening without a long review. I'll try to explain exactly what I did here:
1. I refactored the `DocumentEntity` and the `PostDocumentRequestDto` by removing the `Base64` part and setting the `content` field in the entity to a `CLOB`. I needed to change the tests slightly to reflect this.
2. This caused some changes in the `DocumentsApiController`, which I also ended up refactoring a little to improve the separation of concerns in the POST endpoint.
3. I created the `DispatcherService to remove the dependencies between the `DocumentService, `MinioService`, and `RabbitMQService`. 
4. Because I removed the `Base64` part, I also needed to pass the `MultipartFile` to the `MinioService`. This is advantageous as it greatly simplified the code. We might still need it for something, so I didn't remove the Jackson dependency.
5. I cleaned up a few things I found along the way like stray pieces of commented code or TODO items that are no longer relevant.

I made sure to check every step of the application and it all does work so far, including one significant upgrade: we can now upload larger PDF files, so the tests are a little more realistic.

The DB schema has changed, so if you have trouble testing this on your machine, you'll probably need to delete whatever storage Docker is using for Postgres. I don't know off the top of my head if it will fix the schema if the DB contains any data.