### PR TITLE
OCR Worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,6 @@ services:
       - 8081:8080
     restart: always
     depends_on:
-      db:
-        condition: service_healthy
       minio:
         condition: service_healthy
       rabbitmq:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,12 +125,7 @@ services:
       - 8082:8080
     restart: always
     depends_on:
-      db:
-        condition: service_healthy
-      minio:
-        condition: service_healthy
-      rabbitmq:
-        condition: service_healthy
+      - paperless-rest
 
 volumes:
   rabbitmq-data: {}

--- a/paperlessOCR/Dockerfile
+++ b/paperlessOCR/Dockerfile
@@ -31,6 +31,16 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=temurin /customjre $JAVA_HOME
 COPY --from=temurin ./target/paperlessOCR-1.0-SNAPSHOT.jar ./
 
+# Capture default UID and GID
+# should prevent running java with root privileges
+ENV DEFAULT_UID=${uid:-0}
+ENV DEFAULT_GID=${gid:-0}
+
+# provide directory for the documents to land in
+USER root # the next line will not work without this
+RUN mkdir -p /documents && chmod 777 /documents
+USER ${DEFAULT_UID}:${DEFAULT_GID}
+
 EXPOSE 8080
 
 ENTRYPOINT ["/jre/bin/java", "-jar", "/paperlessOCR-1.0-SNAPSHOT.jar"]

--- a/paperlessOCR/Dockerfile
+++ b/paperlessOCR/Dockerfile
@@ -24,7 +24,9 @@ RUN $JAVA_HOME/bin/jlink \
 
 
 # main app image
-FROM alpine
+# this is the ocr image with the most pulls, so... it's good?
+# https://hub.docker.com/r/jitesoft/tesseract-ocr
+FROM jitesoft/tesseract-ocr:alpine
 ENV JAVA_HOME=/jre
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 

--- a/paperlessOCR/Dockerfile
+++ b/paperlessOCR/Dockerfile
@@ -39,7 +39,7 @@ ENV DEFAULT_UID=${uid:-0}
 ENV DEFAULT_GID=${gid:-0}
 
 # provide directory for the documents to land in
-USER root # the next line will not work without this
+USER root
 RUN mkdir -p /documents && chmod 777 /documents
 USER ${DEFAULT_UID}:${DEFAULT_GID}
 

--- a/paperlessOCR/pom.xml
+++ b/paperlessOCR/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.minio</groupId>
+      <artifactId>minio</artifactId>
+      <version>8.5.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/paperlessOCR/pom.xml
+++ b/paperlessOCR/pom.xml
@@ -55,6 +55,39 @@
       <optional>true</optional>
       <version>1.18.30</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/Main.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/Main.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class Main {
-    // TODO integrate Logger
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);
     }

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/entities/DocumentEntity.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/entities/DocumentEntity.java
@@ -1,0 +1,32 @@
+package at.fhtw.swen3.paperless.ocr.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "document")
+public class DocumentEntity {
+    @Id
+    private Integer id;
+    private Integer correspondent;
+
+    private Integer documentType;
+
+    @NotNull(message = "Document title cannot be null")
+    @NotEmpty(message = "Document title cannot be empty")
+    @Size(max = 40, message = "A valid document title must contain less than 40 characters")
+    private String title;
+
+    @Lob
+    private String content;
+
+    private String createdDate;
+}

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/ConsumerService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/ConsumerService.java
@@ -4,18 +4,26 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import at.fhtw.swen3.paperless.ocr.config.RabbitMQConfig;
+import org.springframework.stereotype.Service;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-@Component
+@Service
 public class ConsumerService {
-    // TODO integrate Logger
+    Logger logger = LogManager.getLogger(ConsumerService.class);
+
+    private final OcrDispatcherService dispatcherService;
+
+    public ConsumerService(OcrDispatcherService dispatcherService) {
+        this.dispatcherService = dispatcherService;
+    }
 
     @RabbitListener(queues = RabbitMQConfig.PAPERLESS_REST_QUEUE)
     public void receive(String message) {
-        try {
-            System.out.println(String.format("Received a message over %s:\n%s",
-                    RabbitMQConfig.PAPERLESS_REST_QUEUE, message));
-        } catch (Exception e) {
-            System.out.println(String.format("Error occurred: %s\n", e));
-        }
+        this.logger.info(String.format("Received a message over %s:\n%s",
+            RabbitMQConfig.PAPERLESS_REST_QUEUE, message));
+
+        // TODO does this need to be threaded?
+        dispatcherService.handleMessage(message);
     }
 }

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/MinioService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/MinioService.java
@@ -1,0 +1,49 @@
+package at.fhtw.swen3.paperless.ocr.services;
+
+import io.minio.GetObjectArgs;
+import io.minio.MinioClient;
+import org.springframework.stereotype.Service;
+import lombok.Getter;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Service
+public class MinioService {
+    Logger logger = LogManager.getLogger(MinioService.class);
+    private final String BUCKET_NAME = "documents";
+
+    @Getter
+    private final MinioClient minioClient =
+        MinioClient.builder().endpoint("http://minio:9000")
+            .credentials("paperless_minio", "paperless").build();
+
+    public Path retrieveFile(String path) {
+        this.logger.info(String.format("Retrieving file: %s\n", path));
+
+        try (InputStream stream =
+            minioClient.getObject(GetObjectArgs
+                .builder()
+                .bucket(BUCKET_NAME)
+                .object(path)
+                .build())) {
+            // Read the stream
+            Path outputPath = Path.of("/", BUCKET_NAME, path);
+            Files.createDirectories(outputPath.getParent());
+            Files.copy(
+                stream,
+                outputPath,
+                StandardCopyOption.REPLACE_EXISTING);
+            this.logger.info(String.format("Successfully retrieved file: %s\n",
+                outputPath.getFileName()));
+            return outputPath;
+        } catch (Exception e) {
+            this.logger.info(String.format("Failed to retrieve file: %s\n", path));
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
@@ -13,19 +13,27 @@ import org.apache.logging.log4j.Logger;
 public class OcrDispatcherService {
     Logger logger = LogManager.getLogger(OcrDispatcherService.class);
 
+    private final MinioService minioService;
+
+    public OcrDispatcherService(MinioService minioService) {
+        this.minioService = minioService;
+    }
+
     public void handleMessage(String message) {
         // deserialize message
+        DocumentEntity document;
         var om = new ObjectMapper();
         try {
-            var document = om.readValue(message, DocumentEntity.class);
+            document = om.readValue(message, DocumentEntity.class);
             this.logger.info(
                 String.format("Successfully parsed document: %s\n", document.getTitle()));
-        } catch (JsonProcessingException e) {
+
+        this.minioService.retrieveFile(document.getTitle());
+        } catch (Exception e) {
             this.logger
-                .error(String.format("Could not parse document object, aborting.\n%s", e));
+                .error(String.format("An error occurred: %s\n", e));
         }
-        // log stuff
-        // run OCR job
-        // when it's done, persist the new content in the entity
+        // TODO run OCR job
+        // TODO persist content in the entity
     }
 }

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
@@ -1,0 +1,31 @@
+package at.fhtw.swen3.paperless.ocr.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import at.fhtw.swen3.paperless.ocr.config.RabbitMQConfig;
+import at.fhtw.swen3.paperless.ocr.entities.DocumentEntity;
+import org.springframework.stereotype.Service;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Service
+public class OcrDispatcherService {
+    Logger logger = LogManager.getLogger(OcrDispatcherService.class);
+
+    public void handleMessage(String message) {
+        // deserialize message
+        var om = new ObjectMapper();
+        try {
+            var document = om.readValue(message, DocumentEntity.class);
+            this.logger.info(
+                String.format("Successfully parsed document: %s\n", document.getTitle()));
+        } catch (JsonProcessingException e) {
+            this.logger
+                .error(String.format("Could not parse document object, aborting.\n%s", e));
+        }
+        // log stuff
+        // run OCR job
+        // when it's done, persist the new content in the entity
+    }
+}

--- a/paperlessOCR/src/main/resources/application.properties
+++ b/paperlessOCR/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 server.port=8080
+
+spring.jpa.show-sql=true
+
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.username=paperless_postgres
+spring.datasource.password=paperless
+
+spring.datasource.url=jdbc:postgresql://db:5432/paperlessdb

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/models/entity/DocumentEntity.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/models/entity/DocumentEntity.java
@@ -1,12 +1,10 @@
 package at.fhtw.swen3.paperless.models.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
-import org.hibernate.validator.constraints.Length;
 
 
 @Getter

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/IDispatcherService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/IDispatcherService.java
@@ -1,8 +1,9 @@
 package at.fhtw.swen3.paperless.services;
 
 import org.springframework.web.multipart.MultipartFile;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import at.fhtw.swen3.paperless.services.customDTOs.PostDocumentRequestDto;
 
 public interface IDispatcherService {
-    void handleDocument(MultipartFile file, PostDocumentRequestDto postDocRequestDto);
+    void handleDocument(MultipartFile file, PostDocumentRequestDto postDocRequestDto) throws JsonProcessingException;
 }

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/messageQueue/MQService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/messageQueue/MQService.java
@@ -21,7 +21,7 @@ public class MQService {
 
     public void processMessage(String message) {
 
-        rabbit.convertAndSend(RabbitMQConfig.PAPERLESS_REST_QUEUE, "Message: " + message);
+        rabbit.convertAndSend(RabbitMQConfig.PAPERLESS_REST_QUEUE, message);
         logger.info(String.format("[ Sent message to %s]", message));
     }
 


### PR DESCRIPTION
This PR is still in progress. ~~It depends on #53 and #54 so those should be merged first, which should make the review on this PR less convoluted.~~

This is the state of things:
* We have a new container for the OCR worker
* The OCR worker is a self-contained Spring Boot application
* It has fairly thorough logging; I think all exceptions are logged and you can follow the different parts of the functionality on the `info` level. Tip: run `docker logs paperless-ocr -f` in your terminal to follow just the OCR logs.
* It knows about the DB, but has no operations implemented yet
* It can listen to the message queue and retrieve messages
* It can connect to Minio and retrieve files (the way it works could definitely be better; this is really an absolutely minimum working setup)
* There is no actual OCR going on yet, but that should consist of: 
  1. Adding an actual `OcrService` to use the `tess4j` API 
  2. Checking to make sure the needed `tesseractdata` is available (I think [this Docker image](https://hub.docker.com/r/jitesoft/tesseract-ocr) has it already configured and we don't need to do anything else here)
  3. Get the actual OCRed text content
  4. Set up a `DocumentRepository` so that we can persist the content to the correct DB field

SHAME ALERT: there are 0 unit tests in this thing...