### PR TITLE
Feature/50 update document in db

### DIFF
--- a/paperlessOCR/pom.xml
+++ b/paperlessOCR/pom.xml
@@ -93,6 +93,11 @@
       <artifactId>minio</artifactId>
       <version>8.5.2</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.tess4j</groupId>
+      <artifactId>tess4j</artifactId>
+      <version>5.6.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/entities/DocumentEntity.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/entities/DocumentEntity.java
@@ -25,7 +25,7 @@ public class DocumentEntity {
     @Size(max = 40, message = "A valid document title must contain less than 40 characters")
     private String title;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     private String createdDate;

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/repositories/DocumentRepository.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/repositories/DocumentRepository.java
@@ -1,0 +1,18 @@
+package at.fhtw.swen3.paperless.ocr.repositories;
+
+import at.fhtw.swen3.paperless.ocr.entities.DocumentEntity;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DocumentRepository extends JpaRepository<DocumentEntity, Integer> {
+
+    //custom method to perform update on document
+    @Transactional //transactional is needed for hibernate to work
+    @Modifying //overwrite default JPA behaviour
+    @Query("update document as d set d.content = :content where d.id = :id")
+    int updateDocumentContentById(@Param("content") String content, @Param("id") Integer id);
+
+}

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/ConsumerService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/ConsumerService.java
@@ -1,8 +1,6 @@
 package at.fhtw.swen3.paperless.ocr.services;
 
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import at.fhtw.swen3.paperless.ocr.config.RabbitMQConfig;
 import org.springframework.stereotype.Service;
 import org.apache.logging.log4j.LogManager;

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/DocumentPostgresService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/DocumentPostgresService.java
@@ -1,0 +1,23 @@
+package at.fhtw.swen3.paperless.ocr.services;
+
+import at.fhtw.swen3.paperless.ocr.repositories.DocumentRepository;
+import at.fhtw.swen3.paperless.ocr.services.interfaces.DocumentDbStorageService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DocumentPostgresService implements DocumentDbStorageService {
+
+    private final DocumentRepository documentRepository;
+
+    public DocumentPostgresService(DocumentRepository documentRepository) {
+        this.documentRepository = documentRepository;
+    }
+
+    @Override
+    public void updateDocumentContent(Integer docId, String parsedDocumentContent) {
+
+        documentRepository.updateDocumentContentById(parsedDocumentContent, docId);
+
+    }
+
+}

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
@@ -1,13 +1,14 @@
 package at.fhtw.swen3.paperless.ocr.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import at.fhtw.swen3.paperless.ocr.services.interfaces.DocumentDbStorageService;
+import at.fhtw.swen3.paperless.ocr.services.interfaces.OcrExecutorService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import at.fhtw.swen3.paperless.ocr.config.RabbitMQConfig;
 import at.fhtw.swen3.paperless.ocr.entities.DocumentEntity;
 import org.springframework.stereotype.Service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Path;
 
 @Service
 public class OcrDispatcherService {
@@ -15,8 +16,14 @@ public class OcrDispatcherService {
 
     private final MinioService minioService;
 
-    public OcrDispatcherService(MinioService minioService) {
+    private final OcrExecutorService ocrExecutorService;
+
+    private final DocumentDbStorageService documentDbStorageService;
+
+    public OcrDispatcherService(MinioService minioService, TesseractService tesseractService, DocumentPostgresService documentPostgresService) {
         this.minioService = minioService;
+        this.ocrExecutorService = tesseractService;
+        this.documentDbStorageService = documentPostgresService;
     }
 
     public void handleMessage(String message) {
@@ -26,14 +33,22 @@ public class OcrDispatcherService {
         try {
             document = om.readValue(message, DocumentEntity.class);
             this.logger.info(
-                String.format("Successfully parsed document: %s\n", document.getTitle()));
+                    String.format("Successfully parsed document: %s\n with id: %s", document.getTitle(), document.getId()));
 
-        this.minioService.retrieveFile(document.getTitle());
+            Path filePath = this.minioService.retrieveFile(document.getTitle());
+            this.logger.info(String.format("File fetched from minIO and temporary stored in: %s", filePath));
+
+            String parsedFileContent = this.ocrExecutorService.executeOcr(filePath.toFile());
+            this.logger.info(String.format("File %s was successfully parsed.\n Content was: \n %s", filePath, parsedFileContent));
+
+            documentDbStorageService.updateDocumentContent(document.getId(), parsedFileContent);
+            this.logger.info(String.format("Successfully updated document content, for document id: %03d", document.getId()));
+
         } catch (Exception e) {
             this.logger
-                .error(String.format("An error occurred: %s\n", e));
+                    .error(String.format("An error occurred: %s\n", e));
         }
-        // TODO run OCR job
-        // TODO persist content in the entity
+
     }
+
 }

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/TesseractService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/TesseractService.java
@@ -1,0 +1,35 @@
+package at.fhtw.swen3.paperless.ocr.services;
+
+import at.fhtw.swen3.paperless.ocr.services.interfaces.OcrExecutorService;
+import net.sourceforge.tess4j.ITesseract;
+import net.sourceforge.tess4j.Tesseract;
+import net.sourceforge.tess4j.TesseractException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+
+@Service
+public class TesseractService implements OcrExecutorService {
+
+    private final String tesseractDataPath;
+
+    public TesseractService(@Value("${tesseract.data.path}") String tesseractDataPath) {
+        this.tesseractDataPath = tesseractDataPath;
+    }
+
+    private ITesseract instantiateTesseract() {
+        ITesseract tesseract = new Tesseract();
+        tesseract.setDatapath(this.tesseractDataPath);
+        return tesseract;
+    }
+
+    @Override
+    public String executeOcr(File file) throws TesseractException {
+
+        ITesseract tesseract = this.instantiateTesseract();
+        return tesseract.doOCR(file);
+
+    }
+
+}

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/DocumentDbStorageService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/DocumentDbStorageService.java
@@ -1,0 +1,5 @@
+package at.fhtw.swen3.paperless.ocr.services.interfaces;
+
+public interface DocumentDbStorageService {
+    public void updateDocumentContent(Integer docId, String parsedDocumentContent);
+}

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/OcrExecutorService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/OcrExecutorService.java
@@ -1,0 +1,11 @@
+package at.fhtw.swen3.paperless.ocr.services.interfaces;
+
+import net.sourceforge.tess4j.TesseractException;
+
+import java.io.File;
+
+public interface OcrExecutorService {
+
+    String executeOcr(File file) throws TesseractException;
+
+}

--- a/paperlessOCR/src/main/resources/application.properties
+++ b/paperlessOCR/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.datasource.username=paperless_postgres
 spring.datasource.password=paperless
 
 spring.datasource.url=jdbc:postgresql://db:5432/paperlessdb
+
+#path comes from the docker image definition: https://github.com/jitesoft/docker-tesseract-ocr/blob/master/alpine/Dockerfile
+tesseract.data.path=/usr/local/share/tessdata

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/models/entity/DocumentEntity.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/models/entity/DocumentEntity.java
@@ -27,7 +27,7 @@ public class DocumentEntity {
     @Size(max = 40, message = "A valid document title must contain less than 40 characters")
     private String title;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     private String createdDate;


### PR DESCRIPTION
I used Skyler's code as a base to implement the update of the documentEntity via the OCR-Worker. For the time being there is some code duplication. Because the RabbitMQConfig and the DocumentEntity are present in both applications, but just copied and pasted. In the future they should handled via a module system.

This PR should be completed after: https://github.com/Grossstadt-Pinguine/SWKOM_Paperless/pull/57