### PR TITLE
Feature/48 move test entity

### DIFF
--- a/paperlessREST/src/test/java/at/fhtw/swen3/paperless/DTOs/TestDto.java
+++ b/paperlessREST/src/test/java/at/fhtw/swen3/paperless/DTOs/TestDto.java
@@ -1,4 +1,4 @@
-package at.fhtw.swen3.paperless.services.customDTOs;
+package at.fhtw.swen3.paperless.DTOs;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/paperlessREST/src/test/java/at/fhtw/swen3/paperless/entities/TestEntity.java
+++ b/paperlessREST/src/test/java/at/fhtw/swen3/paperless/entities/TestEntity.java
@@ -1,4 +1,4 @@
-package at.fhtw.swen3.paperless.models.entity;
+package at.fhtw.swen3.paperless.entities;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/paperlessREST/src/test/java/at/fhtw/swen3/paperless/mapper/TestMapper.java
+++ b/paperlessREST/src/test/java/at/fhtw/swen3/paperless/mapper/TestMapper.java
@@ -1,8 +1,9 @@
-package at.fhtw.swen3.paperless.services.mapper;
+package at.fhtw.swen3.paperless.mapper;
 
 
-import at.fhtw.swen3.paperless.models.entity.TestEntity;
-import at.fhtw.swen3.paperless.services.customDTOs.TestDto;
+import at.fhtw.swen3.paperless.entities.TestEntity;
+import at.fhtw.swen3.paperless.DTOs.TestDto;
+import at.fhtw.swen3.paperless.services.mapper.BaseMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;

--- a/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/TestMapperTests.java
+++ b/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/TestMapperTests.java
@@ -1,8 +1,7 @@
 package at.fhtw.swen3.paperless.services;
 
-import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
-import at.fhtw.swen3.paperless.models.entity.TestEntity;
-import at.fhtw.swen3.paperless.services.mapper.TestMapper;
+import at.fhtw.swen3.paperless.entities.TestEntity;
+import at.fhtw.swen3.paperless.mapper.TestMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 


### PR DESCRIPTION
Moved the test entity, as well as the related files to the test scope. This avoid the unnecessary creation of a testEntity table in the production database.

This PR was created based upon the changes of https://github.com/Grossstadt-Pinguine/SWKOM_Paperless/pull/58 and should be completed after it (transitively also after https://github.com/Grossstadt-Pinguine/SWKOM_Paperless/pull/57)