### PR TITLE
Feature/68 add missing interfaces

### DIFF
--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/ConsumerService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/ConsumerService.java
@@ -1,6 +1,7 @@
 package at.fhtw.swen3.paperless.ocr.services;
 
 import at.fhtw.swen3.paperless.ocr.config.RabbitMQConfig;
+import at.fhtw.swen3.paperless.ocr.services.interfaces.DispatcherService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -10,9 +11,9 @@ import org.springframework.stereotype.Service;
 public class ConsumerService {
     Logger logger = LogManager.getLogger(ConsumerService.class);
 
-    private final OcrDispatcherService dispatcherService;
+    private final DispatcherService dispatcherService;
 
-    public ConsumerService(OcrDispatcherService dispatcherService) {
+    public ConsumerService(DispatcherService dispatcherService) {
         this.dispatcherService = dispatcherService;
     }
 
@@ -21,7 +22,6 @@ public class ConsumerService {
         this.logger.info(String.format("Received a message over %s:\n%s",
             RabbitMQConfig.PAPERLESS_REST_QUEUE, message));
 
-        // TODO does this need to be threaded?
         dispatcherService.handleMessage(message);
     }
 }

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/MinioService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/MinioService.java
@@ -1,5 +1,6 @@
 package at.fhtw.swen3.paperless.ocr.services;
 
+import at.fhtw.swen3.paperless.ocr.services.interfaces.DocumentStoreService;
 import io.minio.GetObjectArgs;
 import io.minio.MinioClient;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 @Service
-public class MinioService {
+public class MinioService implements DocumentStoreService {
     Logger logger = LogManager.getLogger(MinioService.class);
     private final String BUCKET_NAME = "documents";
 
@@ -22,6 +23,7 @@ public class MinioService {
         MinioClient.builder().endpoint("http://minio:9000")
             .credentials("paperless_minio", "paperless").build();
 
+    @Override
     public Path retrieveFile(String path) {
         this.logger.info(String.format("Retrieving file: %s\n", path));
 

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/OcrDispatcherService.java
@@ -1,9 +1,7 @@
 package at.fhtw.swen3.paperless.ocr.services;
 
 import at.fhtw.swen3.paperless.ocr.entities.DocumentEntity;
-import at.fhtw.swen3.paperless.ocr.services.interfaces.DocumentDbStorageService;
-import at.fhtw.swen3.paperless.ocr.services.interfaces.OcrExecutorService;
-import at.fhtw.swen3.paperless.ocr.services.interfaces.SearchService;
+import at.fhtw.swen3.paperless.ocr.services.interfaces.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -12,10 +10,10 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Path;
 
 @Service
-public class OcrDispatcherService {
+public class OcrDispatcherService implements DispatcherService {
     Logger logger = LogManager.getLogger(OcrDispatcherService.class);
 
-    private final MinioService minioService;
+    private final DocumentStoreService minioService;
 
     private final OcrExecutorService ocrExecutorService;
 
@@ -23,13 +21,14 @@ public class OcrDispatcherService {
 
     private final SearchService searchService;
 
-    public OcrDispatcherService(MinioService minioService, TesseractService tesseractService, DocumentPostgresService documentPostgresService, SearchService searchService) {
+    public OcrDispatcherService(DocumentStoreService minioService, TesseractService tesseractService, DocumentPostgresService documentPostgresService, SearchService searchService) {
         this.minioService = minioService;
         this.ocrExecutorService = tesseractService;
         this.documentDbStorageService = documentPostgresService;
         this.searchService = searchService;
     }
 
+    @Override
     public void handleMessage(String message) {
         // deserialize message
         DocumentEntity document;

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/DispatcherService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/DispatcherService.java
@@ -1,0 +1,5 @@
+package at.fhtw.swen3.paperless.ocr.services.interfaces;
+
+public interface DispatcherService {
+    public void handleMessage(String message);
+}

--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/DocumentStoreService.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/services/interfaces/DocumentStoreService.java
@@ -1,0 +1,7 @@
+package at.fhtw.swen3.paperless.ocr.services.interfaces;
+
+import java.nio.file.Path;
+
+public interface DocumentStoreService {
+    public Path retrieveFile(String path);
+}

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/DispatcherService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/DispatcherService.java
@@ -2,8 +2,9 @@ package at.fhtw.swen3.paperless.services;
 
 import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
 import at.fhtw.swen3.paperless.services.customDTOs.PostDocumentRequestDto;
-import at.fhtw.swen3.paperless.services.messageQueue.MQService;
-import at.fhtw.swen3.paperless.services.minio.MinioService;
+import at.fhtw.swen3.paperless.services.document.DocumentService;
+import at.fhtw.swen3.paperless.services.messageQueue.MessageQueueService;
+import at.fhtw.swen3.paperless.services.minio.DocumentStoreService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
@@ -21,12 +22,12 @@ public class DispatcherService implements IDispatcherService {
     Logger logger = LogManager.getLogger(DispatcherService.class);
 
     private final DocumentService documentService;
-    private final MQService mqService;
-    private final MinioService minioService;
+    private final MessageQueueService mqService;
+    private final DocumentStoreService minioService;
 
     @Autowired
-    public DispatcherService(DocumentService documentService, MQService mqService,
-        MinioService minioService) {
+    public DispatcherService(DocumentService documentService, MessageQueueService mqService,
+                             DocumentStoreService minioService) {
         this.documentService = documentService;
         this.mqService = mqService;
         this.minioService = minioService;

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/document/DocumentService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/document/DocumentService.java
@@ -1,4 +1,4 @@
-package at.fhtw.swen3.paperless.services;
+package at.fhtw.swen3.paperless.services.document;
 
 import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
 import at.fhtw.swen3.paperless.repositories.DocumentRepository;

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/document/IDocumentService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/document/IDocumentService.java
@@ -1,4 +1,4 @@
-package at.fhtw.swen3.paperless.services;
+package at.fhtw.swen3.paperless.services.document;
 
 import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
 import at.fhtw.swen3.paperless.services.customDTOs.PostDocumentRequestDto;

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/messageQueue/MessageQueueService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/messageQueue/MessageQueueService.java
@@ -1,0 +1,7 @@
+package at.fhtw.swen3.paperless.services.messageQueue;
+
+public interface MessageQueueService {
+
+    public void processMessage(String message);
+
+}

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/messageQueue/RabbitMQService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/messageQueue/RabbitMQService.java
@@ -8,14 +8,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MQService {
+public class RabbitMQService implements MessageQueueService {
 
     private final RabbitTemplate rabbit;
 
-    private final Logger logger = LogManager.getLogger(MQService.class);
+    private final Logger logger = LogManager.getLogger(RabbitMQService.class);
 
     @Autowired
-    public MQService(RabbitTemplate rabbit) {
+    public RabbitMQService(RabbitTemplate rabbit) {
         this.rabbit = rabbit;
     }
 

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/DocumentStoreService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/DocumentStoreService.java
@@ -1,0 +1,9 @@
+package at.fhtw.swen3.paperless.services.minio;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface DocumentStoreService {
+
+    public void handleFileUpload(MultipartFile document);
+
+}

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/MinioService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/minio/MinioService.java
@@ -13,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.InputStream;
 
 @Component
-public class MinioService {
+public class MinioService implements DocumentStoreService {
 
     Logger logger = LogManager.getLogger(MinioService.class);
 
@@ -47,6 +47,7 @@ public class MinioService {
         }
     }
 
+    @Override
     public void handleFileUpload(MultipartFile document) {
 
         try {

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/search/ElasticSearchService.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/services/search/ElasticSearchService.java
@@ -2,7 +2,7 @@ package at.fhtw.swen3.paperless.services.search;
 
 import at.fhtw.swen3.paperless.config.ElasticSearchClientConfig;
 import at.fhtw.swen3.paperless.models.entity.DocumentEntity;
-import at.fhtw.swen3.paperless.services.DocumentService;
+import at.fhtw.swen3.paperless.services.document.DocumentService;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import org.apache.logging.log4j.LogManager;

--- a/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/DocumentMapperTests.java
+++ b/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/DocumentMapperTests.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SpringBootTest
 public class DocumentMapperTests {
 
     @Test

--- a/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/DocumentMapperTests.java
+++ b/paperlessREST/src/test/java/at/fhtw/swen3/paperless/services/DocumentMapperTests.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest
 public class DocumentMapperTests {
 
     @Test


### PR DESCRIPTION
Added interfaces for services not having them. ConsumerService in paperlessOCR should be left out, since its only method is marked as `@RabbitListener` and could therefore have conflicts with the method declared in the interface