### PR TITLE
RabbitMQ credentials from application properties

### DIFF
--- a/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/config/RabbitMQConfig.java
+++ b/paperlessOCR/src/main/java/at/fhtw/swen3/paperless/ocr/config/RabbitMQConfig.java
@@ -23,10 +23,12 @@ public class RabbitMQConfig {
     @Value("${paperless.rabbitMq.password}")
     private String rabbitMqPwd;
 
+    @Value("${paperless.rabbitMq.hostname}")
+    private String rabbitMqHostname;
 
     @Bean
     public ConnectionFactory connectionFactory() {
-        CachingConnectionFactory connectionFactory = new CachingConnectionFactory("rabbitmq");
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory(this.rabbitMqHostname);
         connectionFactory.setUsername(this.rabbitMqUsername);
         connectionFactory.setPassword(this.rabbitMqPwd);
         return connectionFactory;

--- a/paperlessOCR/src/main/resources/application.properties
+++ b/paperlessOCR/src/main/resources/application.properties
@@ -18,3 +18,4 @@ elasticsearch.port=9200
 
 paperless.rabbitMq.username=paperless_rabbitmq
 paperless.rabbitMq.password=paperless_mq
+paperless.rabbitMq.hostname=rabbitmq

--- a/paperlessREST/src/main/java/at/fhtw/swen3/paperless/config/RabbitMQConfig.java
+++ b/paperlessREST/src/main/java/at/fhtw/swen3/paperless/config/RabbitMQConfig.java
@@ -4,6 +4,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +13,14 @@ public class RabbitMQConfig {
 
     public static final String PAPERLESS_REST_QUEUE = "PAPERLESS_REST";
 
+    @Value("${paperless.rabbitMq.username}")
+    private String rabbitMqUsername;
+
+    @Value("${paperless.rabbitMq.password}")
+    private String rabbitMqPwd;
+
+    @Value("${paperless.rabbitMq.hostname}")
+    private String rabbitMqHostname;
     @Bean
     public Queue paperlessQueue() {
         return new Queue(PAPERLESS_REST_QUEUE, false);
@@ -19,9 +28,9 @@ public class RabbitMQConfig {
 
     @Bean
     public ConnectionFactory connectionFactory() {
-        CachingConnectionFactory connectionFactory = new CachingConnectionFactory("rabbitmq");
-        connectionFactory.setUsername("paperless_rabbitmq");
-        connectionFactory.setPassword("paperless_mq");
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory(this.rabbitMqHostname);
+        connectionFactory.setUsername(this.rabbitMqUsername);
+        connectionFactory.setPassword(this.rabbitMqPwd);
         return connectionFactory;
     }
 

--- a/paperlessREST/src/main/resources/application.properties
+++ b/paperlessREST/src/main/resources/application.properties
@@ -18,3 +18,7 @@ spring.datasource.url=jdbc:postgresql://db:5432/paperlessdb
 
 elasticsearch.host=elasticsearch
 elasticsearch.port=9200
+
+paperless.rabbitMq.username=paperless_rabbitmq
+paperless.rabbitMq.password=paperless_mq
+paperless.rabbitMq.hostname=rabbitmq


### PR DESCRIPTION
Added fetching from application.properties for the RabbitMQ configuration in order to avoid to store the credentials in the class itself